### PR TITLE
Added test cases relate to Network Control Module

### DIFF
--- a/src/commonMethods/commonFunctions.js
+++ b/src/commonMethods/commonFunctions.js
@@ -495,3 +495,81 @@ export const stopWPEFramework = function() {
   stopProcess('WPEFramework')
   return true
 }
+
+/**
+ * This function is used to reload network adapters
+ * @param networkinterface
+ * @returns {Promise<AxiosResponse<any>>}
+ */
+export const reloadNetworkAdapter = function(networkinterface) {
+  return this.$thunder.api.NetworkControl.reload(networkinterface)
+    .then(result => result)
+    .catch(err => err)
+}
+
+/**
+ * This function is used to reload Non-static network adapters
+ * @param networkinterface
+ * @returns {Promise<AxiosResponse<any>>}
+ */
+export const requestNetworkAdapter = function(networkinterface) {
+  return this.$thunder.api.NetworkControl.request(networkinterface)
+    .then(result => result)
+    .catch(err => err)
+}
+
+/**
+ * This function is used to reload static network adapters
+ * @param networkinterface
+ * @returns {Promise<AxiosResponse<any>>}
+ */
+export const assignNetworkAdapter = function(networkinterface) {
+  return this.$thunder.api.NetworkControl.assign(networkinterface)
+    .then(result => result)
+    .catch(err => err)
+}
+
+/**
+ * This function is used to flush network adapters
+ * @param networkinterface
+ * @returns {Promise<AxiosResponse<any>>}
+ */
+export const flushNetworkAdapter = function(networkinterface) {
+  return this.$thunder.api.NetworkControl.flush(networkinterface)
+    .then(result => result)
+    .catch(err => err)
+}
+
+/**
+ * This function is used to get Network Information
+ * @param networkinterface
+ * @returns {Promise<AxiosResponse<any>>}
+ */
+export const getNetworkInformation = function(networkinterface) {
+  return this.$thunder.api.NetworkControl.network(networkinterface)
+    .then(result => result)
+    .catch(err => err)
+}
+
+/**
+ * This function is used to check the Network up status
+ * @param networkinterface
+ * @returns {Promise<AxiosResponse<any>>}
+ */
+export const getNetworkStatus = function(networkinterface) {
+  return this.$thunder.api.NetworkControl.network(networkinterface)
+    .then(result => result)
+    .catch(err => err)
+}
+
+/**
+ * This function is used to check the Network up status
+ * @param networkinterface
+ * @param state
+ * @returns {Promise<AxiosResponse<any>>}
+ */
+export const setNetworkStatus = function(networkinterface, state) {
+  return this.$thunder.api.NetworkControl.network(networkinterface, state)
+    .then(result => result)
+    .catch(err => err)
+}

--- a/src/commonMethods/constants.js
+++ b/src/commonMethods/constants.js
@@ -10,6 +10,9 @@ export default {
   youTubePlugin: 'Cobalt',
   netFlixPlugin: 'Netflix',
   ocdmPlugin: 'OCDM',
+  timeSyncPlugin: 'TimeSync',
+  locationSyncPlugin: 'LocationSync',
+  networkControlPlugin: 'NetworkControl',
   ocdmImplementation: 'OCDMImplementation',
   snapshotPlugin: 'Snapshot',
   webServerPlugin: 'WebServer',
@@ -19,6 +22,7 @@ export default {
   provisioningPlugin: 'Provisioning',
   WPEProcess: 'WPEProcess',
   remoteControlPlugin: 'RemoteControl',
+  invalidAddress: 'invalidstring',
 
   //Plugin states
   activate: 'activate',
@@ -29,4 +33,3 @@ export default {
   blankUrl: 'about:blank',
   host: config.thunder.host,
 }
-

--- a/src/tests/networkcontrol/NetworkControl_Assign_001.test.js
+++ b/src/tests/networkcontrol/NetworkControl_Assign_001.test.js
@@ -1,0 +1,41 @@
+import {
+  pluginDeactivate,
+  pluginActivate,
+  assignNetworkAdapter,
+} from '../../commonMethods/commonFunctions'
+import constants from '../../commonMethods/constants'
+
+export default {
+  title: 'NetworkControl - Assign 001',
+  description: 'Check the Assign Functionality of Network Control Module',
+  steps: [
+    {
+      description: 'Check if NetworkControl Plugin is stopped correctly',
+      test: pluginDeactivate,
+      params: constants.networkControlPlugin,
+      assert: 'deactivated',
+    },
+    {
+      description: 'Check if NetworkControl Plugin is started correctly',
+      test: pluginActivate,
+      params: constants.networkControlPlugin,
+      assert: 'activated',
+    },
+    {
+      description: 'Invoke Assign',
+      sleep: 5,
+      test() {
+        return assignNetworkAdapter().call(this, 'eth0')
+      },
+      validate(res) {
+        //TODO - Update validation by confirming that assign happened
+        if (res == null) {
+          return true
+        } else {
+          this.$log('Assign doesnt work')
+          return false
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/networkcontrol/NetworkControl_Assign_002.test.js
+++ b/src/tests/networkcontrol/NetworkControl_Assign_002.test.js
@@ -1,0 +1,41 @@
+import {
+  pluginDeactivate,
+  pluginActivate,
+  assignNetworkAdapter,
+} from '../../commonMethods/commonFunctions'
+import constants from '../../commonMethods/constants'
+
+export default {
+  title: 'NetworkControl - Assign 002',
+  description:
+    'Check the Assign Functionality of Network Control Module with invalid network interface',
+  steps: [
+    {
+      description: 'Check if NetworkControl Plugin is stopped correctly',
+      test: pluginDeactivate,
+      params: constants.networkControlPlugin,
+      assert: 'deactivated',
+    },
+    {
+      description: 'Check if NetworkControl Plugin is started correctly',
+      test: pluginActivate,
+      params: constants.networkControlPlugin,
+      assert: 'activated',
+    },
+    {
+      description: 'Invoke Assign with invalid network interface',
+      sleep: 5,
+      test() {
+        return assignNetworkAdapter().call(this, constants.invalidAddress)
+      },
+      validate(res) {
+        if (res.code === 2 && res.message === 'ERROR_UNAVAILABLE') {
+          return true
+        } else {
+          this.$log('Proper error message is not shown')
+          return false
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/networkcontrol/NetworkControl_Flush_001.test.js
+++ b/src/tests/networkcontrol/NetworkControl_Flush_001.test.js
@@ -1,0 +1,41 @@
+import {
+  pluginDeactivate,
+  pluginActivate,
+  flushNetworkAdapter,
+} from '../../commonMethods/commonFunctions'
+import constants from '../../commonMethods/constants'
+
+export default {
+  title: 'NetworkControl - Flush 001',
+  description: 'Check the Flush Functionality of Network Control Module',
+  steps: [
+    {
+      description: 'Check if NetworkControl Plugin is stopped correctly',
+      test: pluginDeactivate,
+      params: constants.networkControlPlugin,
+      assert: 'deactivated',
+    },
+    {
+      description: 'Check if NetworkControl Plugin is started correctly',
+      test: pluginActivate,
+      params: constants.networkControlPlugin,
+      assert: 'activated',
+    },
+    {
+      description: 'Invoke Flush',
+      sleep: 5,
+      test() {
+        return flushNetworkAdapter.call(this, 'eth0')
+      },
+      validate(res) {
+        //TODO - Update validation by confirming that flush happened
+        if (res == null) {
+          return true
+        } else {
+          this.$log('Flush doesnt work')
+          return false
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/networkcontrol/NetworkControl_Flush_002.test.js
+++ b/src/tests/networkcontrol/NetworkControl_Flush_002.test.js
@@ -1,0 +1,41 @@
+import {
+  pluginDeactivate,
+  pluginActivate,
+  flushNetworkAdapter,
+} from '../../commonMethods/commonFunctions'
+import constants from '../../commonMethods/constants'
+
+export default {
+  title: 'NetworkControl - Flush 002',
+  description:
+    'Check the Flush Functionality of Network Control Module with invalid Network Interface',
+  steps: [
+    {
+      description: 'Check if NetworkControl Plugin is stopped correctly',
+      test: pluginDeactivate,
+      params: constants.networkControlPlugin,
+      assert: 'deactivated',
+    },
+    {
+      description: 'Check if NetworkControl Plugin is started correctly',
+      test: pluginActivate,
+      params: constants.networkControlPlugin,
+      assert: 'activated',
+    },
+    {
+      description: 'Invoke Flush with invalid network interface',
+      sleep: 5,
+      test() {
+        return flushNetworkAdapter.call(this, constants.invalidAddress)
+      },
+      validate(res) {
+        if (res.code === 2 && res.message === 'ERROR_UNAVAILABLE') {
+          return true
+        } else {
+          this.$log('Proper error message is not shown')
+          return false
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/networkcontrol/NetworkControl_Network_001.test.js
+++ b/src/tests/networkcontrol/NetworkControl_Network_001.test.js
@@ -1,0 +1,47 @@
+import {
+  pluginDeactivate,
+  pluginActivate,
+  getNetworkInformation,
+} from '../../commonMethods/commonFunctions'
+import constants from '../../commonMethods/constants'
+
+export default {
+  title: 'NetworkControl - NetworkInfo 001',
+  description: 'Check the Network Information of Network Control Module',
+  steps: [
+    {
+      description: 'Check if NetworkControl Plugin is stopped correctly',
+      test: pluginDeactivate,
+      params: constants.networkControlPlugin,
+      assert: 'deactivated',
+    },
+    {
+      description: 'Check if NetworkControl Plugin is started correctly',
+      test: pluginActivate,
+      params: constants.networkControlPlugin,
+      assert: 'activated',
+    },
+    {
+      description: 'Invoke Network to get Network Info',
+      sleep: 5,
+      test() {
+        return getNetworkInformation.call(this, 'eth0')
+      },
+      validate(res) {
+        if (
+          res.interface != null &&
+          res.mode != null &&
+          res.address != null &&
+          res.mask != null &&
+          res.gateway != null &&
+          res.broadcast != null
+        ) {
+          return true
+        } else {
+          this.$log('Network Info Not available')
+          return false
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/networkcontrol/NetworkControl_Network_002.test.js
+++ b/src/tests/networkcontrol/NetworkControl_Network_002.test.js
@@ -1,0 +1,41 @@
+import {
+  pluginDeactivate,
+  pluginActivate,
+  getNetworkInformation,
+} from '../../commonMethods/commonFunctions'
+import constants from '../../commonMethods/constants'
+
+export default {
+  title: 'NetworkControl - NetworkInfo 002',
+  description:
+    'Check the Network Information of Network Control Module with invalid network interface',
+  steps: [
+    {
+      description: 'Check if NetworkControl Plugin is stopped correctly',
+      test: pluginDeactivate,
+      params: constants.networkControlPlugin,
+      assert: 'deactivated',
+    },
+    {
+      description: 'Check if NetworkControl Plugin is started correctly',
+      test: pluginActivate,
+      params: constants.networkControlPlugin,
+      assert: 'activated',
+    },
+    {
+      description: 'Invoke Network to get Network Info with invalid network interface',
+      sleep: 5,
+      test() {
+        return getNetworkInformation.call(this, constants.invalidAddress)
+      },
+      validate(res) {
+        if (res.code === 2 && res.message === 'ERROR_UNAVAILABLE') {
+          return true
+        } else {
+          this.$log('Proper error message is not shown')
+          return false
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/networkcontrol/NetworkControl_Reload_001.test.js
+++ b/src/tests/networkcontrol/NetworkControl_Reload_001.test.js
@@ -1,0 +1,41 @@
+import {
+  pluginDeactivate,
+  pluginActivate,
+  reloadNetworkAdapter,
+} from '../../commonMethods/commonFunctions'
+import constants from '../../commonMethods/constants'
+
+export default {
+  title: 'NetworkControl - Reload 001',
+  description: 'Check the Reload Functionality of Network Control Module',
+  steps: [
+    {
+      description: 'Check if NetworkControl Plugin is stopped correctly',
+      test: pluginDeactivate,
+      params: constants.networkControlPlugin,
+      assert: 'deactivated',
+    },
+    {
+      description: 'Check if NetworkControl Plugin is started correctly',
+      test: pluginActivate,
+      params: constants.networkControlPlugin,
+      assert: 'activated',
+    },
+    {
+      description: 'Invoke Reload',
+      sleep: 5,
+      test() {
+        return reloadNetworkAdapter.call(this, 'eth0')
+      },
+      validate(res) {
+        //TODO - Update validation by confirming that reload happened
+        if (res == null) {
+          return true
+        } else {
+          this.$log('Reload doesnt work')
+          return false
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/networkcontrol/NetworkControl_Reload_002.test.js
+++ b/src/tests/networkcontrol/NetworkControl_Reload_002.test.js
@@ -1,0 +1,41 @@
+import {
+  pluginDeactivate,
+  pluginActivate,
+  reloadNetworkAdapter,
+} from '../../commonMethods/commonFunctions'
+import constants from '../../commonMethods/constants'
+
+export default {
+  title: 'NetworkControl - Reload 002',
+  description:
+    'Check the Reload Functionality of Network Control Module with invalid network interface',
+  steps: [
+    {
+      description: 'Check if NetworkControl Plugin is stopped correctly',
+      test: pluginDeactivate,
+      params: constants.networkControlPlugin,
+      assert: 'deactivated',
+    },
+    {
+      description: 'Check if NetworkControl Plugin is started correctly',
+      test: pluginActivate,
+      params: constants.networkControlPlugin,
+      assert: 'activated',
+    },
+    {
+      description: 'Invoke Reload with invalid Network interface',
+      sleep: 5,
+      test() {
+        return reloadNetworkAdapter.call(this, constants.invalidAddress)
+      },
+      validate(res) {
+        if (res.code === 2 && res.message === 'ERROR_UNAVAILABLE') {
+          return true
+        } else {
+          this.$log('Proper error message is not shown')
+          return false
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/networkcontrol/NetworkControl_Request_001.test.js
+++ b/src/tests/networkcontrol/NetworkControl_Request_001.test.js
@@ -1,0 +1,41 @@
+import {
+  pluginDeactivate,
+  pluginActivate,
+  requestNetworkAdapter,
+} from '../../commonMethods/commonFunctions'
+import constants from '../../commonMethods/constants'
+
+export default {
+  title: 'NetworkControl - Request 001',
+  description: 'Check the Request Functionality of Network Control Module',
+  steps: [
+    {
+      description: 'Check if NetworkControl Plugin is stopped correctly',
+      test: pluginDeactivate,
+      params: constants.networkControlPlugin,
+      assert: 'deactivated',
+    },
+    {
+      description: 'Check if NetworkControl Plugin is started correctly',
+      test: pluginActivate,
+      params: constants.networkControlPlugin,
+      assert: 'activated',
+    },
+    {
+      description: 'Invoke Request',
+      sleep: 5,
+      test() {
+        return requestNetworkAdapter.call(this, 'eth0')
+      },
+      validate(res) {
+        //TODO - Update validation by confirming that Request happened
+        if (res == null) {
+          return true
+        } else {
+          this.$log('Request doesnt work')
+          return false
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/networkcontrol/NetworkControl_Request_002.test.js
+++ b/src/tests/networkcontrol/NetworkControl_Request_002.test.js
@@ -1,0 +1,41 @@
+import {
+  pluginDeactivate,
+  pluginActivate,
+  requestNetworkAdapter,
+} from '../../commonMethods/commonFunctions'
+import constants from '../../commonMethods/constants'
+
+export default {
+  title: 'NetworkControl - Request 002',
+  description:
+    'Check the Request Functionality of Network Control Module with invalid network interface',
+  steps: [
+    {
+      description: 'Check if NetworkControl Plugin is stopped correctly',
+      test: pluginDeactivate,
+      params: constants.networkControlPlugin,
+      assert: 'deactivated',
+    },
+    {
+      description: 'Check if NetworkControl Plugin is started correctly',
+      test: pluginActivate,
+      params: constants.networkControlPlugin,
+      assert: 'activated',
+    },
+    {
+      description: 'Invoke Request with invalid network interface',
+      sleep: 5,
+      test() {
+        return requestNetworkAdapter.call(this, constants.invalidAddress)
+      },
+      validate(res) {
+        if (res.code === 2 && res.message === 'ERROR_UNAVAILABLE') {
+          return true
+        } else {
+          this.$log('Proper error message is not shown')
+          return false
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/networkcontrol/NetworkControl_Status_001.test.js
+++ b/src/tests/networkcontrol/NetworkControl_Status_001.test.js
@@ -1,0 +1,40 @@
+import {
+  pluginDeactivate,
+  pluginActivate,
+  getNetworkStatus,
+} from '../../commonMethods/commonFunctions'
+import constants from '../../commonMethods/constants'
+
+export default {
+  title: 'NetworkControl - Up Status 001',
+  description: 'Check the Network Up status',
+  steps: [
+    {
+      description: 'Check if NetworkControl Plugin is stopped correctly',
+      test: pluginDeactivate,
+      params: constants.networkControlPlugin,
+      assert: 'deactivated',
+    },
+    {
+      description: 'Check if NetworkControl Plugin is started correctly',
+      test: pluginActivate,
+      params: constants.networkControlPlugin,
+      assert: 'activated',
+    },
+    {
+      description: 'Invoke Up to check network status',
+      sleep: 5,
+      test() {
+        return getNetworkStatus.call(this, 'eth0')
+      },
+      validate(res) {
+        if (res === true) {
+          return true
+        } else {
+          this.$log('Network Status Not available')
+          return false
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/networkcontrol/NetworkControl_Status_002.test.js
+++ b/src/tests/networkcontrol/NetworkControl_Status_002.test.js
@@ -1,0 +1,40 @@
+import {
+  pluginDeactivate,
+  pluginActivate,
+  getNetworkStatus,
+} from '../../commonMethods/commonFunctions'
+import constants from '../../commonMethods/constants'
+
+export default {
+  title: 'NetworkControl - Up Status 002',
+  description: 'Check the Network Up status with invalid network interface',
+  steps: [
+    {
+      description: 'Check if NetworkControl Plugin is stopped correctly',
+      test: pluginDeactivate,
+      params: constants.networkControlPlugin,
+      assert: 'deactivated',
+    },
+    {
+      description: 'Check if NetworkControl Plugin is started correctly',
+      test: pluginActivate,
+      params: constants.networkControlPlugin,
+      assert: 'activated',
+    },
+    {
+      description: 'Invoke Up to check network status with invalid network interface',
+      sleep: 5,
+      test() {
+        return getNetworkStatus.call(this, constants.invalidAddress)
+      },
+      validate(res) {
+        if (res.code === 2 && res.message === 'ERROR_UNAVAILABLE') {
+          return true
+        } else {
+          this.$log('Proper error message is not shown')
+          return false
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/networkcontrol/NetworkControl_Status_003.test.js
+++ b/src/tests/networkcontrol/NetworkControl_Status_003.test.js
@@ -1,0 +1,40 @@
+import {
+  pluginDeactivate,
+  pluginActivate,
+  setNetworkStatus,
+} from '../../commonMethods/commonFunctions'
+import constants from '../../commonMethods/constants'
+
+export default {
+  title: 'NetworkControl - Up Status 003',
+  description: 'Set the Network Up status to True',
+  steps: [
+    {
+      description: 'Check if NetworkControl Plugin is stopped correctly',
+      test: pluginDeactivate,
+      params: constants.networkControlPlugin,
+      assert: 'deactivated',
+    },
+    {
+      description: 'Check if NetworkControl Plugin is started correctly',
+      test: pluginActivate,
+      params: constants.networkControlPlugin,
+      assert: 'activated',
+    },
+    {
+      description: 'Invoke Up to check network status',
+      sleep: 5,
+      test() {
+        return setNetworkStatus.call(this, 'eth0', 'false') //TODO - Network status cannot be set to false as the connection is lost.
+      },
+      validate(res) {
+        if (res === null) {
+          return true
+        } else {
+          this.$log('Cannot set network status')
+          return false
+        }
+      },
+    },
+  ],
+}


### PR DESCRIPTION
Following are the test cases that are added in this PR : 
NetworkControl_Assign_001.test.js
NetworkControl_Assign_002.test.js
NetworkControl_Flush_001.test.js
NetworkControl_Flush_002.test.js
NetworkControl_Network_001.test.js
NetworkControl_Network_002.test.js
NetworkControl_Reload_001.test.js
NetworkControl_Reload_002.test.js
NetworkControl_Request_001.test.js
NetworkControl_Request_002.test.js
NetworkControl_Status_001.test.js
NetworkControl_Status_002.test.js
NetworkControl_Status_003.test.js