### PR TITLE
Updated timesync cases with minor code changes

### DIFF
--- a/src/tests/timesync/TimeSync_SyncTime_001.test.js
+++ b/src/tests/timesync/TimeSync_SyncTime_001.test.js
@@ -16,10 +16,10 @@ export default {
           return getLatestSyncTime.call(this)
         },
         validate(res) {
-          let result = Moment(res)
-          let currTime = Moment()
+          let result = Moment.utc(res.time)
+          let currTime = Moment.utc()
           let timeDiff = currTime.diff(result)
-          if (timeDiff < 3000) {
+          if (timeDiff < 15000) {
             return true
           } else {
             throw new Error('Current Time is not provided')

--- a/src/tests/timesync/TimeSync_Synchronize_001.test.js
+++ b/src/tests/timesync/TimeSync_Synchronize_001.test.js
@@ -2,8 +2,6 @@ import { pluginActivate, pluginDeactivate } from '../../commonMethods/controller
 import { syncTime } from '../../commonMethods/timeSync'
 import constants from '../../commonMethods/constants'
 
-let listener
-
 export default {
   title: 'TimeSync - Synchronize 001',
   description: 'Check the Synchronize Functionality of TimeSync Module',
@@ -11,16 +9,7 @@ export default {
     return this.$sequence([
       () => pluginDeactivate.call(this, constants.timeSyncPlugin),
       () => pluginActivate.call(this, constants.timeSyncPlugin),
-      () => {
-        this.$data.write('timechanged', false)
-        listener = this.$thunder.api.TimeSync.on('timechange', () => {
-          this.$data.write('timechanged', true)
-        })
-      },
     ])
-  },
-  teardown() {
-    listener.dispose
   },
   steps: [
     {
@@ -35,25 +24,6 @@ export default {
         } else {
           throw new Error('Sync does not start')
         }
-      },
-    },
-    {
-      description: 'Check whether time sync is success',
-      sleep: 5,
-      test() {
-        return new Promise((resolve, reject) => {
-          let attempts = 0
-          const interval = setInterval(() => {
-            attempts++
-            if (this.$data.read('timechanged') === true) {
-              clearInterval(interval)
-              resolve()
-            } else if (attempts > 20) {
-              clearInterval(interval)
-              reject('Time Sync not completed')
-            }
-          }, 1000)
-        })
       },
     },
   ],

--- a/src/tests/timesync/TimeSync_Synchronize_003.test.js
+++ b/src/tests/timesync/TimeSync_Synchronize_003.test.js
@@ -57,8 +57,7 @@ export default {
     },
     {
       description: 'Check whether time sync is success',
-      sleep: 5,
-      test() {
+      sleep() {
         return new Promise((resolve, reject) => {
           let attempts = 0
           const interval = setInterval(() => {
@@ -73,10 +72,6 @@ export default {
           }, 1000)
         })
       },
-    },
-    {
-      description: 'Invoke Time to get current time',
-      sleep: 5,
       test() {
         return getCurrentTime.call(this)
       },

--- a/src/tests/timesync/TimeSync_Time_001.test.js
+++ b/src/tests/timesync/TimeSync_Time_001.test.js
@@ -6,19 +6,13 @@ import Moment from 'moment'
 export default {
   title: 'TimeSync - GetTime 001',
   description: 'Check the latest Time returned from TimeSync Module',
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.timeSyncPlugin),
+      () => pluginActivate.call(this, constants.timeSyncPlugin),
+    ])
+  },
   steps: [
-    {
-      description: 'Check if TimeSync Plugin is stopped correctly',
-      test: pluginDeactivate,
-      params: constants.timeSyncPlugin,
-      assert: 'deactivated',
-    },
-    {
-      description: 'Check if Time Sync Plugin is started correctly',
-      test: pluginActivate,
-      params: constants.timeSyncPlugin,
-      assert: 'activated',
-    },
     {
       description: 'Invoke Time to get current time',
       sleep: 5,
@@ -26,8 +20,8 @@ export default {
         return getCurrentTime.call(this)
       },
       validate(res) {
-        let result = Moment(res)
-        let currTime = Moment()
+        let result = Moment.utc(res)
+        let currTime = Moment.utc()
         let timeDiff = currTime.diff(result)
         if (timeDiff < 3000) {
           return true

--- a/src/tests/timesync/TimeSync_Time_002.test.js
+++ b/src/tests/timesync/TimeSync_Time_002.test.js
@@ -6,19 +6,13 @@ import Moment from 'moment'
 export default {
   title: 'TimeSync - GetTime 002',
   description: 'Check the latest Time returned from TimeSync Module',
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.timeSyncPlugin),
+      () => pluginActivate.call(this, constants.timeSyncPlugin),
+    ])
+  },
   steps: [
-    {
-      description: 'Check if TimeSync Plugin is stopped correctly',
-      test: pluginDeactivate,
-      params: constants.timeSyncPlugin,
-      assert: 'deactivated',
-    },
-    {
-      description: 'Check if Time Sync Plugin is started correctly',
-      test: pluginActivate,
-      params: constants.timeSyncPlugin,
-      assert: 'activated',
-    },
     {
       description: 'Set Time to current time',
       sleep: 5,

--- a/src/tests/timesync/TimeSync_Time_003.test.js
+++ b/src/tests/timesync/TimeSync_Time_003.test.js
@@ -5,19 +5,13 @@ import constants from '../../commonMethods/constants'
 export default {
   title: 'TimeSync - GetTime 003',
   description: 'Check the error message when we set wrong time format',
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.timeSyncPlugin),
+      () => pluginActivate.call(this, constants.timeSyncPlugin),
+    ])
+  },
   steps: [
-    {
-      description: 'Check if TimeSync Plugin is stopped correctly',
-      test: pluginDeactivate,
-      params: constants.timeSyncPlugin,
-      assert: 'deactivated',
-    },
-    {
-      description: 'Check if Time Sync Plugin is started correctly',
-      test: pluginActivate,
-      params: constants.timeSyncPlugin,
-      assert: 'activated',
-    },
     {
       description: 'Set Time to Invalid time and validate the error',
       sleep: 5,


### PR DESCRIPTION
Following are the changes in this PR: 
1. Re-organzied the code by moving deactivate/activate to setup
2. Fixed timezone to utc so that the test execution doesn't depend on time zones