### PR TITLE
Added remote control test cases for json format error

### DIFF
--- a/src/commonMethods/remoteControl.js
+++ b/src/commonMethods/remoteControl.js
@@ -109,3 +109,92 @@ export const modifyRemoteControlKey = function(device, code, keyvalue, modifiers
     .then(result => result)
     .catch(err => err)
 }
+
+/**
+ * This function loads the device's keymap
+ * @param device
+ * @returns {Promise<T>}
+ */
+export const loadDeviceKeyMap = function(device) {
+  return this.$thunder.api.RemoteControl.load({ device: device })
+    .then(result => result)
+    .catch(err => err)
+}
+
+/**
+ * This function saves the device keymap
+ * @param device
+ * @returns {Promise<T>}
+ */
+export const saveDeviceKeyMap = function(device) {
+  return this.$thunder.api.RemoteControl.save({ device: device })
+    .then(result => result)
+    .catch(err => err)
+}
+
+/**
+ * This function pairs with the specified remotecontrol device
+ * @param device
+ * @returns {Promise<T>}
+ */
+export const pairRemoteControlDevice = function(device) {
+  return this.$thunder.api.RemoteControl.pair({ device: device })
+    .then(result => result)
+    .catch(err => err)
+}
+
+/**
+ * This function un-pairs with the specified remotecontrol device
+ * @param device
+ * @param bindId
+ * @returns {Promise<T>}
+ */
+export const unpairRemoteControlDevice = function(device, bindId) {
+  return this.$thunder.api.RemoteControl.unpair({ device: device, bindid: bindId })
+    .then(result => result)
+    .catch(err => err)
+}
+
+/**
+ * This function is used to generate the error - 'Error json format' for LOAD API
+ * @param device
+ * @returns {Promise<T>}
+ */
+export const loadFunctionForError = function(device) {
+  return this.$thunder.api.RemoteControl.load({ devices: device })
+    .then(result => result)
+    .catch(err => err)
+}
+
+/**
+ * This function is used to generate the error - 'Error json format' for SAVE API
+ * @param device
+ * @returns {Promise<T>}
+ */
+export const saveFunctionForError = function(device) {
+  return this.$thunder.api.RemoteControl.save({ devices: device })
+    .then(result => result)
+    .catch(err => err)
+}
+
+/**
+ * This function is used to generate the error - 'Error json format' for PAIR API
+ * @param device
+ * @returns {Promise<T>}
+ */
+export const pairFunctionForError = function(device) {
+  return this.$thunder.api.RemoteControl.pair({ devices: device })
+    .then(result => result)
+    .catch(err => err)
+}
+
+/**
+ * This function is used to generate the error - 'Error json format' for UNPAIR API
+ * @param device
+ * @returns {Promise<T>}
+ */
+export const unpairFunctionForError = function(device) {
+  return this.$thunder.api.RemoteControl.unpair({ devices: device })
+    .then(result => result)
+    .catch(err => err)
+}

--- a/src/tests/remotecontrol/RemoteControl_Add_004.test.js
+++ b/src/tests/remotecontrol/RemoteControl_Add_004.test.js
@@ -1,0 +1,39 @@
+import { pluginActivate, pluginDeactivate } from '../../commonMethods/controller'
+import constants from '../../commonMethods/constants'
+import { addRemoteControlKey } from '../../commonMethods/remoteControl'
+
+export default {
+  title: 'RemoteControl Add - 004',
+  description: 'Validate Thunder response when Add is invoked with Invalid Json Format',
+  context: {
+    deviceName: 'DevInput',
+    keyCode: '1,',
+    key: 103,
+  },
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.remoteControlPlugin),
+      () => pluginActivate.call(this, constants.remoteControlPlugin),
+    ])
+  },
+  steps: [
+    {
+      description: 'Invoke Add with invalid json format and validate the result',
+      test() {
+        return addRemoteControlKey.call(
+          this,
+          this.$context.read('deviceName'),
+          this.$context.read('keyCode'),
+          this.$context.read('key')
+        )
+      },
+      validate(res) {
+        if (res.code === 30 && res.message === 'ERROR_BAD_REQUEST') {
+          return true
+        } else {
+          throw new Error(`Error message is improper and is ${res}`)
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/remotecontrol/RemoteControl_Delete_004.test.js
+++ b/src/tests/remotecontrol/RemoteControl_Delete_004.test.js
@@ -1,0 +1,37 @@
+import { pluginActivate, pluginDeactivate } from '../../commonMethods/controller'
+import constants from '../../commonMethods/constants'
+import { deleteRemoteControlKey } from '../../commonMethods/remoteControl'
+
+export default {
+  title: 'RemoteControl Delete - 004',
+  description: 'Validate Thunder response when Delete is invoked with Invalid Json Format',
+  context: {
+    deviceName: 'DevInput',
+    keyCode: '1,',
+  },
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.remoteControlPlugin),
+      () => pluginActivate.call(this, constants.remoteControlPlugin),
+    ])
+  },
+  steps: [
+    {
+      description: 'Invoke Modify with invalid json format and validate the result',
+      test() {
+        return deleteRemoteControlKey.call(
+          this,
+          this.$context.read('deviceName'),
+          this.$context.read('keyCode')
+        )
+      },
+      validate(res) {
+        if (res.code === 30 && res.message === 'ERROR_BAD_REQUEST') {
+          return true
+        } else {
+          throw new Error(`Error message is improper and is ${res}`)
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/remotecontrol/RemoteControl_Key_004.test.js
+++ b/src/tests/remotecontrol/RemoteControl_Key_004.test.js
@@ -1,0 +1,37 @@
+import { pluginActivate, pluginDeactivate } from '../../commonMethods/controller'
+import constants from '../../commonMethods/constants'
+import { getKeyCodeDetails } from '../../commonMethods/remoteControl'
+
+export default {
+  title: 'RemoteControl Key - 004',
+  description: 'Validate Thunder response when Key is invoked with Invalid Json Format',
+  context: {
+    deviceName: 'DevInput',
+    code: '1,',
+  },
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.remoteControlPlugin),
+      () => pluginActivate.call(this, constants.remoteControlPlugin),
+    ])
+  },
+  steps: [
+    {
+      description: 'Invoke Key with invalid json format and validate the result',
+      test() {
+        return getKeyCodeDetails.call(
+          this,
+          this.$context.read('deviceName'),
+          this.$context.read('code')
+        )
+      },
+      validate(res) {
+        if (res.code === 30 && res.message === 'ERROR_BAD_REQUEST') {
+          return true
+        } else {
+          throw new Error(`Error message is improper and is ${res}`)
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/remotecontrol/RemoteControl_Load_003.test.js
+++ b/src/tests/remotecontrol/RemoteControl_Load_003.test.js
@@ -1,0 +1,32 @@
+import { pluginActivate, pluginDeactivate } from '../../commonMethods/controller'
+import constants from '../../commonMethods/constants'
+import { loadDeviceKeyMap, loadFunctionForError } from '../../commonMethods/remoteControl'
+
+export default {
+  title: 'RemoteControl Load - 003 ',
+  description: 'Validate Thunder response when Load is invoked with Invalid Json Format',
+  context: {
+    deviceName: 'DevInput',
+  },
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.remoteControlPlugin),
+      () => pluginActivate.call(this, constants.remoteControlPlugin),
+    ])
+  },
+  steps: [
+    {
+      description: 'Invoke Load with invalid json format and validate the result',
+      test() {
+        return loadFunctionForError.call(this, this.$context.read('deviceName'))
+      },
+      validate(res) {
+        if (res.code === 30 && res.message === 'ERROR_BAD_REQUEST') {
+          return true
+        } else {
+          throw new Error(`Error message is improper and is ${res}`)
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/remotecontrol/RemoteControl_Modify_004.test.js
+++ b/src/tests/remotecontrol/RemoteControl_Modify_004.test.js
@@ -1,0 +1,41 @@
+import { pluginActivate, pluginDeactivate } from '../../commonMethods/controller'
+import constants from '../../commonMethods/constants'
+import { modifyRemoteControlKey } from '../../commonMethods/remoteControl'
+
+export default {
+  title: 'RemoteControl Modify - 004',
+  description: 'Validate Thunder response when Modify is invoked with Invalid Json Format',
+  context: {
+    deviceName: 'DevInput',
+    keyCode: '1,',
+    key: 103,
+    modifier: ['leftshift'],
+  },
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.remoteControlPlugin),
+      () => pluginActivate.call(this, constants.remoteControlPlugin),
+    ])
+  },
+  steps: [
+    {
+      description: 'Invoke Modify with invalid json format and validate the result',
+      test() {
+        return modifyRemoteControlKey.call(
+          this,
+          this.$context.read('deviceName'),
+          this.$context.read('keyCode'),
+          this.$context.read('key'),
+          this.$context.read('modifier')
+        )
+      },
+      validate(res) {
+        if (res.code === 30 && res.message === 'ERROR_BAD_REQUEST') {
+          return true
+        } else {
+          throw new Error(`Error message is improper and is ${res}`)
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/remotecontrol/RemoteControl_Pair_003.test.js
+++ b/src/tests/remotecontrol/RemoteControl_Pair_003.test.js
@@ -1,0 +1,32 @@
+import { pluginActivate, pluginDeactivate } from '../../commonMethods/controller'
+import constants from '../../commonMethods/constants'
+import { pairFunctionForError } from '../../commonMethods/remoteControl'
+
+export default {
+  title: 'RemoteControl Pair - 003 ',
+  description: 'Validate Thunder response when Pair is invoked with Invalid Json Format',
+  context: {
+    deviceName: 'DevInput,',
+  },
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.remoteControlPlugin),
+      () => pluginActivate.call(this, constants.remoteControlPlugin),
+    ])
+  },
+  steps: [
+    {
+      description: 'Invoke Pair with invalid json format and validate the result',
+      test() {
+        return pairFunctionForError.call(this, this.$context.read('deviceName'))
+      },
+      validate(res) {
+        if (res.code === 30 && res.message === 'ERROR_BAD_REQUEST') {
+          return true
+        } else {
+          throw new Error(`Error message is improper and is ${res}`)
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/remotecontrol/RemoteControl_Press_004.test.js
+++ b/src/tests/remotecontrol/RemoteControl_Press_004.test.js
@@ -1,0 +1,37 @@
+import { pluginActivate, pluginDeactivate } from '../../commonMethods/controller'
+import constants from '../../commonMethods/constants'
+import { pressKeyCodeToDevice } from '../../commonMethods/remoteControl'
+
+export default {
+  title: 'RemoteControl Press - 004',
+  description: 'Validate Thunder response when Press is invoked with Invalid Json Format',
+  context: {
+    deviceName: 'DevInput',
+    code: '1,',
+  },
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.remoteControlPlugin),
+      () => pluginActivate.call(this, constants.remoteControlPlugin),
+    ])
+  },
+  steps: [
+    {
+      description: 'Invoke Press with invalid json format and validate the result',
+      test() {
+        return pressKeyCodeToDevice.call(
+          this,
+          this.$context.read('deviceName'),
+          this.$context.read('code')
+        )
+      },
+      validate(res) {
+        if (res.code === 30 && res.message === 'ERROR_BAD_REQUEST') {
+          return true
+        } else {
+          throw new Error(`Error message is improper and is ${res}`)
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/remotecontrol/RemoteControl_Release_005.test.js
+++ b/src/tests/remotecontrol/RemoteControl_Release_005.test.js
@@ -1,0 +1,33 @@
+import { pluginActivate, pluginDeactivate } from '../../commonMethods/controller'
+import constants from '../../commonMethods/constants'
+import { releaseKey } from '../../commonMethods/remoteControl'
+
+export default {
+  title: 'RemoteControl Release - 005',
+  description: 'Validate Thunder response when Release is invoked with Invalid Json Format',
+  context: {
+    deviceName: 'Web',
+    code: '1,',
+  },
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.remoteControlPlugin),
+      () => pluginActivate.call(this, constants.remoteControlPlugin),
+    ])
+  },
+  steps: [
+    {
+      description: 'Invoke Send with invalid json format and validate the result',
+      test() {
+        return releaseKey.call(this, this.$context.read('deviceName'), this.$context.read('code'))
+      },
+      validate(res) {
+        if (res.code === 30 && res.message === 'ERROR_BAD_REQUEST') {
+          return true
+        } else {
+          throw new Error(`Error message is improper and is ${res}`)
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/remotecontrol/RemoteControl_Save_003.test.js
+++ b/src/tests/remotecontrol/RemoteControl_Save_003.test.js
@@ -1,0 +1,32 @@
+import { pluginActivate, pluginDeactivate } from '../../commonMethods/controller'
+import constants from '../../commonMethods/constants'
+import { saveDeviceKeyMap, saveFunctionForError } from '../../commonMethods/remoteControl'
+
+export default {
+  title: 'RemoteControl Save - 003',
+  description: 'Validate Thunder response when Save is invoked with Invalid Json Format',
+  context: {
+    deviceName: 'DevInput,',
+  },
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.remoteControlPlugin),
+      () => pluginActivate.call(this, constants.remoteControlPlugin),
+    ])
+  },
+  steps: [
+    {
+      description: 'Invoke Save with invalid json format and validate the result',
+      test() {
+        return saveFunctionForError.call(this, this.$context.read('deviceName'))
+      },
+      validate(res) {
+        if (res.code === 30 && res.message === 'ERROR_BAD_REQUEST') {
+          return true
+        } else {
+          throw new Error(`Error message is improper and is ${res}`)
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/remotecontrol/RemoteControl_Send_004.test.js
+++ b/src/tests/remotecontrol/RemoteControl_Send_004.test.js
@@ -1,0 +1,37 @@
+import { pluginActivate, pluginDeactivate } from '../../commonMethods/controller'
+import constants from '../../commonMethods/constants'
+import { sendKeyCodeToDevice } from '../../commonMethods/remoteControl'
+
+export default {
+  title: 'RemoteControl Send - 004',
+  description: 'Validate Thunder response when Send is invoked with Invalid Json Format',
+  context: {
+    deviceName: 'DevInput',
+    code: '1,',
+  },
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.remoteControlPlugin),
+      () => pluginActivate.call(this, constants.remoteControlPlugin),
+    ])
+  },
+  steps: [
+    {
+      description: 'Invoke Send with invalid json format and validate the result',
+      test() {
+        return sendKeyCodeToDevice.call(
+          this,
+          this.$context.read('deviceName'),
+          this.$context.read('code')
+        )
+      },
+      validate(res) {
+        if (res.code === 30 && res.message === 'ERROR_BAD_REQUEST') {
+          return true
+        } else {
+          throw new Error(`Error message is improper and is ${res}`)
+        }
+      },
+    },
+  ],
+}

--- a/src/tests/remotecontrol/RemoteControl_Unpair_003.test.js
+++ b/src/tests/remotecontrol/RemoteControl_Unpair_003.test.js
@@ -1,0 +1,37 @@
+import { pluginActivate, pluginDeactivate } from '../../commonMethods/controller'
+import constants from '../../commonMethods/constants'
+import { unpairFunctionForError } from '../../commonMethods/remoteControl'
+
+export default {
+  title: 'RemoteControl Unpair - 002 ',
+  description: 'Validate Thunder response when Pair is invoked with Invalid Json Format',
+  context: {
+    deviceName: 'invalidDevice',
+    bindingID: 'id',
+  },
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.remoteControlPlugin),
+      () => pluginActivate.call(this, constants.remoteControlPlugin),
+    ])
+  },
+  steps: [
+    {
+      description: 'Invoke unpair with invalid json format and validate the result',
+      test() {
+        return unpairFunctionForError.call(
+          this,
+          this.$context.read('deviceName'),
+          this.$context.read('bindingID')
+        )
+      },
+      validate(res) {
+        if (res.code === 30 && res.message === 'ERROR_BAD_REQUEST') {
+          return true
+        } else {
+          throw new Error(`Error message is improper and is ${res}`)
+        }
+      },
+    },
+  ],
+}


### PR DESCRIPTION
Following are the test cases that are added in this PR : 
RemoteControl_Add_004.test.js 
RemoteControl_Delete_004.test.js 
RemoteControl_Key_004.test.js 
RemoteControl_Load_003.test.js 
RemoteControl_Modify_004.test.js 
RemoteControl_Pair_003.test.js 
RemoteControl_Press_004.test.js 
RemoteControl_Release_005.test.js 
RemoteControl_Save_003.test.js 
RemoteControl_Send_004.test.js 
RemoteControl_Unpair_003.test.js