### PR TITLE
Updated power test cases

### DIFF
--- a/src/tests/powerplugin/PowerPlugin_001.test.js
+++ b/src/tests/powerplugin/PowerPlugin_001.test.js
@@ -13,28 +13,10 @@ export default {
   },
   context: {
     powerState: 'on',
-    timeOut: 0,
   },
   steps: [
     {
-      description: 'Set power state and validate the result',
-      test() {
-        return setPowerState.call(
-          this,
-          this.$context.read('powerState'),
-          this.$context.read('timeOut')
-        )
-      },
-      validate(res) {
-        if (res === null) {
-          return true
-        } else {
-          throw new Error('Error while setting the power state')
-        }
-      },
-    },
-    {
-      description: 'Get power state and validate whether it is as per the setted power state',
+      description: 'Get power state and validate whether it is as per the default power state',
       test() {
         return getPowerState.call(this)
       },

--- a/src/tests/powerplugin/PowerPlugin_002.test.js
+++ b/src/tests/powerplugin/PowerPlugin_002.test.js
@@ -1,13 +1,82 @@
-import baseTest from './PowerPlugin_001.test'
+import { setPowerState, getPowerState } from '../../commonMethods/powerPlugin'
+import { pluginActivate, pluginDeactivate } from '../../commonMethods/controller'
+import constants from '../../commonMethods/constants'
 
 export default {
-  ...baseTest,
-  ...{
-    title: 'Power Plugin - 002',
-    description: 'Sets the Power state to activestandby and validate the result',
-    context: {
-      powerState: 'activestandby',
-      timeOut: 1,
-    },
+  title: 'Power Plugin - 002',
+  description: 'Sets the Power state to activeStandby and validate the result',
+  setup() {
+    return this.$sequence([
+      () => pluginDeactivate.call(this, constants.powerPlugin),
+      () => pluginActivate.call(this, constants.powerPlugin),
+    ])
   },
+  context: {
+    powerState: 'activestandby',
+    powerStateOn: 'on',
+    timeOut: 0,
+  },
+  steps: [
+    {
+      description: 'Set power state and validate the result',
+      sleep: 5,
+      test() {
+        return setPowerState.call(
+          this,
+          this.$context.read('powerState'),
+          this.$context.read('timeOut')
+        )
+      },
+      validate(res) {
+        if (res === null) {
+          return true
+        } else {
+          throw new Error('Error while setting the power state')
+        }
+      },
+    },
+    {
+      description: 'Get power state and validate whether it is as per the setted power state',
+      test() {
+        return getPowerState.call(this)
+      },
+      validate(res) {
+        if (res === this.$context.read('powerState')) {
+          return true
+        } else {
+          throw new Error(`Power state not set to ${this.$context.read('powerState')}`)
+        }
+      },
+    },
+    {
+      description: 'Set power state to ON and validate the result',
+      test() {
+        return setPowerState.call(
+          this,
+          this.$context.read('powerStateOn'),
+          this.$context.read('timeOut')
+        )
+      },
+      validate(res) {
+        if (res === null) {
+          return true
+        } else {
+          throw new Error('Error while setting the power state')
+        }
+      },
+    },
+    {
+      description: 'Get power state and validate whether it is as per the setted power state',
+      test() {
+        return getPowerState.call(this)
+      },
+      validate(res) {
+        if (res === this.$context.read('powerStateOn')) {
+          return true
+        } else {
+          throw new Error(`Power state not set to ${this.$context.read('powerState')}`)
+        }
+      },
+    },
+  ],
 }


### PR DESCRIPTION
Following are the changes in this PR : 
1. Updated PowerPlugin_001.test.js to make sure to get the default power state when the device is up rather than setting the powerstate to on(as the device power state is on when we power on the device)
2. Updated PowerPlugin_002.test.js to set the power state to activestandby and then set to on and validate the result